### PR TITLE
Force primary index

### DIFF
--- a/lib/consolidatable/base.rb
+++ b/lib/consolidatable/base.rb
@@ -31,11 +31,11 @@ module Consolidatable
                     consolidations_alias[:consolidatable_id]
                       .eq(consolidatables_arel[:id])
                       .and(consolidations_alias[:consolidatable_type].eq(klass))
-                      .and(consolidations_alias[:var_name].eq(as))
-                      .and(consolidations_alias[:var_type].eq(type))
                   )
                   .join_sources
               )
+              .where(consolidations_alias[:var_name].eq(as))
+              .where(consolidations_alias[:var_type].eq(type))
           end
         )
       )


### PR DESCRIPTION
Consolidatable used to join columns based on all attributes (consolidatable_type, consolidatable_id, var_name, and var_type).
This could lead some database to use less cardinal columns to filter matching consolidations:

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=434180.50..434180.93 rows=3 width=218) (actual time=1528.161..1591.662 rows=3 loops=1)
   ->  Unique  (cost=434180.50..531566.17 rows=688401 width=218) (actual time=1528.159..1591.660 rows=3 loops=1)                                                                                                                                   
         ->  Gather Merge  (cost=434180.50..514356.15 rows=688401 width=218) (actual time=1528.158..1591.652 rows=3 loops=1)
               Workers Planned: 2                                                                                        
               Workers Launched: 2                                                                                       
               ->  Sort  (cost=433180.48..433897.57 rows=286834 width=218) (actual time=1510.024..1510.078 rows=130 loops=3)
                     Sort Key: blog_approve_ratio_alias.float_value DESC, blogs_count_alias.integer_value DESC, photos.id, photos.url, photos.width, photos.height, photos.caption, photos.created_at, photos.updated_at, photos.labels_count
                     Sort Method: external merge  Disk: 35464kB
                     Worker 0:  Sort Method: external merge  Disk: 51448kB                                                                                                                                                                         
                     Worker 1:  Sort Method: external merge  Disk: 46376kB                                                                                                                                                                         
                     ->  Parallel Hash Left Join  (cost=277056.66..346391.18 rows=286834 width=218) (actual time=820.997..1142.276 rows=225870 loops=3)
                           Hash Cond: (photos.id = blogs_count_alias.consolidatable_id)                  
                           ->  Parallel Hash Left Join  (cost=140212.89..208471.77 rows=286834 width=210) (actual time=684.081..912.837 rows=225870 loops=3)
                                 Hash Cond: (photos.id = blog_approve_ratio_alias.consolidatable_id)
                                 ->  Parallel Seq Scan on photos  (cost=0.00..49625.29 rows=286834 width=202) (actual time=3.161..151.092 rows=225870 loops=3)
                                       Filter: ((status)::text = 'unrated'::text)                                    
                                       Rows Removed by Filter: 283733                                                                                                                                                                              
                                 ->  Parallel Hash  (cost=136843.76..136843.76 rows=193770 width=16) (actual time=378.677..378.678 rows=295458 loops=3)
                                       Buckets: 131072 (originally 131072)  Batches: 32 (originally 8)  Memory Usage: 3200kB
                                       ->  Parallel Seq Scan on consolidations blog_approve_ratio_alias  (cost=0.00..136843.76 rows=193770 width=16) (actual time=0.008..193.586 rows=295458 loops=3)
                                             Filter: (((consolidatable_type)::text = 'Photo'::text) AND ((var_name)::text = 'blog_approve_ratio'::text) AND ((var_type)::text = 'float'::text))
                                             Rows Removed by Filter: 201682                                                                                                                                                                        
                           ->  Parallel Hash  (cost=136843.76..136843.76 rows=1 width=16) (actual time=136.790..136.791 rows=1537 loops=3)                                         
                                 Buckets: 8192 (originally 1024)  Batches: 1 (originally 1)  Memory Usage: 376kB                                                                                                                                   
                                 ->  Parallel Seq Scan on consolidations blogs_count_alias  (cost=0.00..136843.76 rows=1 width=16) (actual time=88.352..135.239 rows=1537 loops=3)
                                       Filter: (((consolidatable_type)::text = 'Photo'::text) AND ((var_name)::text = 'blogs_count'::text) AND ((var_type)::text = 'integer'::text))                      
                                       Rows Removed by Filter: 495603                                                                                                                                                                              
 Planning Time: 0.451 ms                                                                                                 
 Execution Time: 1597.954 ms                                                                                                                                                                                                                       
(29 rows)
```

The important part being in the Parallel Scans:
```
Filter: (((consolidatable_type)::text = 'Photo'::text) AND ((var_name)::text = 'blog_approve_ratio'::text) AND ((var_type)::text = 'float'::text))
```
There are at max _n * m_ consolidations in the table for one specific model, where n = number of rows for the model, and m = the number of consolidated attributes.
The filter returns _n_ results (the number of rows of the model).
This change forces the database to use the index and returning _m_ results, dramatically reducing the time needed for the scan:

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=137853.23..137853.37 rows=1 width=218) (actual time=281.670..283.644 rows=3 loops=1)
   ->  Unique  (cost=137853.23..137853.37 rows=1 width=218) (actual time=281.668..283.642 rows=3 loops=1)
         ->  Gather Merge  (cost=137853.23..137853.35 rows=1 width=218) (actual time=281.668..283.636 rows=3 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Sort  (cost=136853.20..136853.21 rows=1 width=218) (actual time=268.014..268.027 rows=205 loops=3)
                     Sort Key: blog_approve_ratio_alias.float_value DESC, blogs_count_alias.integer_value DESC, photos.id, photos.url, photos.width, photos.height, photos.caption, photos.created_at, photos.updated_at, photos.labels_count
                     Sort Method: quicksort  Memory: 573kB
                     Worker 0:  Sort Method: quicksort  Memory: 285kB
                     Worker 1:  Sort Method: quicksort  Memory: 165kB
                     ->  Nested Loop  (cost=0.98..136853.19 rows=1 width=218) (actual time=158.887..266.763 rows=1162 loops=3)
                           ->  Nested Loop  (cost=0.55..136852.35 rows=1 width=32) (actual time=158.867..257.750 rows=1691 loops=3)
                                 ->  Parallel Seq Scan on consolidations blogs_count_alias  (cost=0.00..136843.76 rows=1 width=16) (actual time=158.839..248.577 rows=1691 loops=3)
                                       Filter: (((consolidatable_type)::text = 'Photo'::text) AND ((var_name)::text = 'blogs_count'::text) AND ((var_type)::text = 'integer'::text))
                                       Rows Removed by Filter: 495603
                                 ->  Index Scan using consolidations_main_index on consolidations blog_approve_ratio_alias  (cost=0.55..8.58 rows=1 width=16) (actual time=0.005..0.005 rows=1 loops=5072)
                                       Index Cond: ((consolidatable_id = blogs_count_alias.consolidatable_id) AND ((consolidatable_type)::text = 'Photo'::text) AND ((var_name)::text = 'blog_approve_ratio'::text))
                                       Filter: ((var_type)::text = 'float'::text)
                           ->  Index Scan using photos_pkey on photos  (cost=0.43..0.84 rows=1 width=202) (actual time=0.003..0.003 rows=1 loops=5072)
                                 Index Cond: (id = blog_approve_ratio_alias.consolidatable_id)
                                 Filter: ((status)::text = 'unrated'::text)
                                 Rows Removed by Filter: 0
 Planning Time: 0.518 ms
 Execution Time: 283.701 ms
(24 rows)
```