### PR TITLE
Add filtering capabilities to consolidated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,55 @@ Will provide you the five nonprofits with the highest (cached) values for `total
 
 If you need to `.count` the query, you must use `.count(:all)`.
 
+## Filtering Consolidated Values
+
+The gem provides a flexible filtering API similar to ActiveRecord's `where` clause. You can filter records based on their consolidated values using various comparison operators.
+
+### Basic Usage
+
+```ruby
+# Simple equality
+User.where_consolidated(avg_order_value: 100.0)
+
+# Comparison operators
+User.where_consolidated(avg_order_value: { gt: 100.0 })
+User.where_consolidated(avg_order_value: { lt: 50.0 })
+User.where_consolidated(total_orders: { gte: 10 })
+User.where_consolidated(lifetime_value: { lte: 1000.0 })
+
+# Multiple conditions
+User.where_consolidated(
+  avg_order_value: { gt: 100.0 },
+  total_orders: { gte: 10 }
+)
+
+# Null value handling
+User.where_consolidated(avg_order_value: { null: true })  # Find users with no avg_order_value
+User.where_consolidated(avg_order_value: { null: false }) # Find users with any avg_order_value
+```
+
+### Convenience Methods
+
+For common comparisons, the following shorthand methods are available:
+
+```ruby
+User.where_consolidated_gt(:avg_order_value, 100.0)  # Greater than
+User.where_consolidated_gte(:avg_order_value, 100.0) # Greater than or equal to
+User.where_consolidated_lt(:avg_order_value, 50.0)   # Less than
+User.where_consolidated_lte(:avg_order_value, 50.0)  # Less than or equal to
+```
+
+### Chainability
+
+All filtering methods return an ActiveRecord::Relation, so they can be chained with other scopes:
+
+```ruby
+User
+  .where(active: true)
+  .where_consolidated(avg_order_value: { gt: 100.0 })
+  .order(created_at: :desc)
+```
+
 ## Calculating the new value
 Using the default `InlineFetcher`, Consolidatable computes the requested value if the cache is stale or doesn't exist yet. In those cases **_Consolidatable will attempt to write to the database_**, even though you are calling a getter.
 

--- a/lib/consolidatable/base.rb
+++ b/lib/consolidatable/base.rb
@@ -75,6 +75,8 @@ module Consolidatable
 
         table_alias = Consolidatable::Consolidation.arel_table.alias("#{as}_alias")
         type = consolidations_config[as][:type]
+        var_name = table_alias[:var_name]
+        type_value = table_alias["#{type}_value"]
 
         # Join with the consolidation table if not already joined
         scope = scope.send(:"with_#{as}")
@@ -84,49 +86,47 @@ module Consolidatable
           value.each do |operator, operand|
             case operator.to_sym
             when :gt, :greater_than
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].gt(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.gt(operand))
             when :gte, :greater_than_or_equal_to
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].gteq(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.gteq(operand))
             when :lt, :less_than
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].lt(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.lt(operand))
             when :lte, :less_than_or_equal_to
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].lteq(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.lteq(operand))
             when :not_eq, :not_equal_to
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where.not(table_alias["#{type}_value"].eq(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where.not(type_value.eq(operand))
             when :eq, :equal_to
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].eq(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.eq(operand))
             when :in
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].in(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.in(operand))
             when :not_in
-              scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias["#{type}_value"].not_in(operand))
+              scope = scope.where(var_name.eq(as))
+              scope = scope.where(type_value.not_in(operand))
             when :null
               if operand
                 # For null values, we either want no consolidation record or a null value
                 scope = scope.where(
                   table_alias[:id].eq(nil).or(
-                    table_alias[:var_name].eq(as).and(
-                      table_alias[:"#{type}_value"].eq(nil)
-                    )
+                    var_name.eq(as).and(type_value.eq(nil))
                   )
                 )
               else
-                scope = scope.where(table_alias[:var_name].eq(as))
-                scope = scope.where.not(table_alias[:"#{type}_value"].eq(nil))
+                scope = scope.where(var_name.eq(as))
+                scope = scope.where.not(type_value.eq(nil))
               end
             end
           end
         else
           # Simple equality when just a value is provided
-          scope = scope.where(table_alias[:var_name].eq(as))
-          scope = scope.where(table_alias[:"#{type}_value"].eq(value))
+          scope = scope.where(var_name.eq(as))
+          scope = scope.where(type_value.eq(value))
         end
       end
 

--- a/lib/consolidatable/base.rb
+++ b/lib/consolidatable/base.rb
@@ -71,6 +71,8 @@ module Consolidatable
 
       conditions.each do |field, value|
         as = "consolidated_#{field}"
+        raise ArgumentError, "#{field} is not a consolidated field" unless @@consolidate_methods.include?(as)
+
         table_alias = Consolidatable::Consolidation.arel_table.alias("#{as}_alias")
         type = consolidations_config[as][:type]
 
@@ -83,28 +85,28 @@ module Consolidatable
             case operator.to_sym
             when :gt, :greater_than
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].gt(operand))
+              scope = scope.where(table_alias["#{type}_value"].gt(operand))
             when :gte, :greater_than_or_equal_to
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].gteq(operand))
+              scope = scope.where(table_alias["#{type}_value"].gteq(operand))
             when :lt, :less_than
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].lt(operand))
+              scope = scope.where(table_alias["#{type}_value"].lt(operand))
             when :lte, :less_than_or_equal_to
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].lteq(operand))
+              scope = scope.where(table_alias["#{type}_value"].lteq(operand))
             when :not_eq, :not_equal_to
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where.not(table_alias[:"#{type}_value"].eq(operand))
+              scope = scope.where.not(table_alias["#{type}_value"].eq(operand))
             when :eq, :equal_to
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].eq(operand))
+              scope = scope.where(table_alias["#{type}_value"].eq(operand))
             when :in
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].in(operand))
+              scope = scope.where(table_alias["#{type}_value"].in(operand))
             when :not_in
               scope = scope.where(table_alias[:var_name].eq(as))
-              scope = scope.where(table_alias[:"#{type}_value"].not_in(operand))
+              scope = scope.where(table_alias["#{type}_value"].not_in(operand))
             when :null
               if operand
                 # For null values, we either want no consolidation record or a null value
@@ -147,8 +149,6 @@ module Consolidatable
     def where_consolidated_lte(field, value)
       where_consolidated(field => { lte: value })
     end
-
-    private
 
     def consolidations_config
       @consolidations_config ||= {}

--- a/spec/consolidatable/consolidatable_filter_spec.rb
+++ b/spec/consolidatable/consolidatable_filter_spec.rb
@@ -98,4 +98,3 @@ RSpec.describe Consolidatable do
     end
   end
 end
-

--- a/spec/consolidatable/consolidatable_filter_spec.rb
+++ b/spec/consolidatable/consolidatable_filter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Consolidatable do
       child1.consolidated_heaviest_present
       allow(present).to receive(:heaviest_present).and_return(15.0)
       child2.consolidated_heaviest_present
-      allow(present).to receive(:heaviest_present).and_return(5.0)
+      allow(present).to receive(:heaviest_present).and_return(13.0)
       child3.consolidated_heaviest_present
     end
 

--- a/spec/consolidatable/consolidatable_filter_spec.rb
+++ b/spec/consolidatable/consolidatable_filter_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+RSpec.describe Consolidatable do
+  let(:present) do
+    class_double(Present).as_stubbed_const(transfer_nested_constants: true)
+  end
+
+  before do
+    Child.send(:consolidates, :avg_price)
+    Child.send(:consolidates, :heaviest_present)
+  end
+
+  describe 'filtering consolidated values' do
+    let!(:child1) { Child.create(name: 'child1') }
+    let!(:child2) { Child.create(name: 'child2') }
+    let!(:child3) { Child.create(name: 'child3') }
+    let!(:child4) { Child.create(name: 'child4') }  # No consolidation values
+
+    before do
+      # Set up avg_price consolidations
+      allow(present).to receive(:avg_price).and_return(5.0)
+      child1.consolidated_avg_price
+      allow(present).to receive(:avg_price).and_return(2.0)
+      child2.consolidated_avg_price
+      allow(present).to receive(:avg_price).and_return(8.0)
+      child3.consolidated_avg_price
+
+      # Set up heaviest_present consolidations
+      allow(present).to receive(:heaviest_present).and_return(10.0)
+      child1.consolidated_heaviest_present
+      allow(present).to receive(:heaviest_present).and_return(15.0)
+      child2.consolidated_heaviest_present
+      allow(present).to receive(:heaviest_present).and_return(5.0)
+      child3.consolidated_heaviest_present
+    end
+
+    context 'with simple equality' do
+      it 'filters by exact value' do
+        result = Child.where_consolidated(avg_price: 5.0)
+        expect(result).to contain_exactly(child1)
+      end
+    end
+
+    context 'with comparison operators' do
+      it 'filters with greater than' do
+        result = Child.where_consolidated(avg_price: { gt: 5.0 })
+        expect(result).to contain_exactly(child3)
+      end
+
+      it 'filters with greater than or equal to' do
+        result = Child.where_consolidated(avg_price: { gte: 5.0 })
+        expect(result).to contain_exactly(child1, child3)
+      end
+
+      it 'filters with less than' do
+        result = Child.where_consolidated(avg_price: { lt: 5.0 })
+        expect(result).to contain_exactly(child2)
+      end
+
+      it 'filters with less than or equal to' do
+        result = Child.where_consolidated(avg_price: { lte: 5.0 })
+        expect(result).to contain_exactly(child1, child2)
+      end
+    end
+
+    context 'with multiple fields' do
+      it 'combines conditions for different fields' do
+        result = Child.where_consolidated(
+          avg_price: { gt: 2.0 },
+          heaviest_present: { lt: 12.0 }
+        )
+        expect(result).to contain_exactly(child1)
+      end
+    end
+
+    context 'with null values' do
+      it 'filters for null values' do
+        result = Child.where_consolidated(avg_price: { null: true })
+        expect(result).to contain_exactly(child4)
+      end
+
+      it 'filters for non-null values' do
+        result = Child.where_consolidated(avg_price: { null: false })
+        expect(result).to contain_exactly(child1, child2, child3)
+      end
+    end
+
+    context 'with convenience methods' do
+      it 'provides shorthand for greater than' do
+        result = Child.where_consolidated_gt(:avg_price, 5.0)
+        expect(result).to contain_exactly(child3)
+      end
+
+      it 'provides shorthand for less than' do
+        result = Child.where_consolidated_lt(:avg_price, 5.0)
+        expect(result).to contain_exactly(child2)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This change adds the ability to filter records based on their consolidated values, similar to ActiveRecord's where clause. It supports:
- Simple equality filtering
- Comparison operators (gt, lt, gte, lte)
- Multiple field conditions
- Null value handling
- Convenience methods for common operations

The implementation maintains chainability with other ActiveRecord scopes and follows Rails conventions for a familiar API."